### PR TITLE
Rename project from "congchungonline" to "Trustify" across package.json, README.md, wrangler.toml, deployment configuration, and HTML/manifest files.

### DIFF
--- a/.github/workflows/deploy-cloudfare.yml
+++ b/.github/workflows/deploy-cloudfare.yml
@@ -30,4 +30,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy --project-name congchungonline --branch deploy-cloudfare ./build
+          command: pages deploy --project-name trustify --branch deploy-cloudfare ./build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Online Notarization Management System - Frontend
+# Trustify - Frontend
 
-This repository contains the frontend code for **Online Notarization Management System**, a platform for online notarization services that leverages blockchain and NFT for document storage. This frontend interacts with the provided backend to facilitate the user experience.
+This repository contains the frontend code for **Trustify**, a platform for online notarization services that leverages blockchain and NFT for document storage. This frontend interacts with the provided backend to facilitate the user experience.
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "congchungonline-fe",
+  "name": "trustify",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <title>Công chứng trực tuyến</title>
+  <title>Trustify</title>
 </head>
 
 <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Trustify",
+  "name": "Trustify",
   "icons": [
     {
       "src": "favicon.ico",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "congchungonline"
+name = "trustify"
 type = "javascript" 
 pages_build_output_dir = "./build"
 


### PR DESCRIPTION
This pull request primarily focuses on rebranding the application from "Công chứng trực tuyến" (or "congchungonline") to "Trustify." The changes span across multiple files to update the project name, metadata, and related identifiers.

### Rebranding Updates:

* [`.github/workflows/deploy-cloudfare.yml`](diffhunk://#diff-39d6998552869e8757fd7a48a1ae8479736f5b8b4ca3ae277eca44084c1ce2b2L33-R33): Updated the Cloudflare deployment command to use the new project name `trustify` instead of `congchungonline`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R3): Replaced references to "Online Notarization Management System" and "congchungonline" with "Trustify" to reflect the new branding.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R2): Changed the project name from `congchungonline-fe` to `trustify`.
* [`public/index.html`](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL25-R25): Updated the `<title>` tag to display "Trustify" instead of "Công chứng trực tuyến."
* [`public/manifest.json`](diffhunk://#diff-639916bc14c3f311c31f629a2ec116292a4b2f64d06b3607b9ddd2e495703895L2-R3): Modified the `short_name` and `name` fields to "Trustify" for consistency with the new branding.
* [`wrangler.toml`](diffhunk://#diff-b1b9719b6eae4103d520f1e902420f5073b5e18a5a47aa73feed71a037557c98L1-R1): Renamed the Cloudflare Pages project from `congchungonline` to `trustify`.