### PR TITLE
chore: enable GitHub Sponsors button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,6 @@
+# Funding Configuration
+# GitHub Sponsors
+github: [sloweyyy]
+
+# Custom funding links
+# custom: ['https://buymeacoffee.com/sloweyyy']


### PR DESCRIPTION
Adds `.github/FUNDING.yml` pointing at the [sloweyyy GitHub Sponsors profile](https://github.com/sponsors/sloweyyy), enabling the Sponsor button on this repo's page.